### PR TITLE
fix type of RnnInit in recurrent.py

### DIFF
--- a/src/deepsysid/networks/rnn.py
+++ b/src/deepsysid/networks/rnn.py
@@ -73,7 +73,7 @@ class BasicLSTM(HiddenStateForwardModule):
         return x, (h0, c0)
 
 
-class BasicRnn(nn.Module):
+class BasicRnn(HiddenStateForwardModule):
     def __init__(
         self,
         input_dim: int,
@@ -103,10 +103,17 @@ class BasicRnn(nn.Module):
 
     def forward(
         self,
-        u: torch.Tensor,
-        hx: Tuple[torch.Tensor, torch.Tensor],
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        h, _ = self.predictor_rnn(u, hx[0])
+        x_pred: torch.Tensor,
+        hx: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        n_batch, _, _ = x_pred.shape
+
+        if hx is not None:
+            x = hx[0]
+        else:
+            x = torch.zeros((n_batch, self.recurrent_dim))
+
+        h, _ = self.predictor_rnn(x_pred, x)
         return self.out(h), h
 
 

--- a/src/deepsysid/pipeline/testing/stability/bibo.py
+++ b/src/deepsysid/pipeline/testing/stability/bibo.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import List, Optional
 
 import numpy as np
@@ -46,6 +47,8 @@ class BiboStabilityTest(BaseStabilityTest):
 
         test_sequence_results: List[TestSequenceResult] = []
 
+        time_start_test = time.time()
+
         if isinstance(self.evaluation_sequence, int):
             logger.info(
                 f'Test bibo stability for sequence number {self.evaluation_sequence}'
@@ -82,7 +85,14 @@ class BiboStabilityTest(BaseStabilityTest):
                         true_control=sim.true_control,
                     )
                 )
-        return TestResult(sequences=test_sequence_results, metadata=dict())
+
+        time_end_test = time.time()
+
+        test_time = time_end_test - time_start_test
+
+        return TestResult(
+            sequences=test_sequence_results, metadata=dict(test_time=[test_time])
+        )
 
     def evaluate_stability_of_sequence(
         self,

--- a/src/deepsysid/pipeline/testing/stability/incremental.py
+++ b/src/deepsysid/pipeline/testing/stability/incremental.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import List, Optional
 
 import numpy as np
@@ -46,6 +47,8 @@ class IncrementalStabilityTest(BaseStabilityTest):
 
         test_sequence_results = []
 
+        time_start_test = time.time()
+
         if isinstance(self.evaluation_sequence, int):
             logger.info(
                 'Test incremental stability'
@@ -86,7 +89,13 @@ class IncrementalStabilityTest(BaseStabilityTest):
                     )
                 )
 
-        return TestResult(sequences=test_sequence_results, metadata=dict())
+        time_end_test = time.time()
+
+        test_time = time_end_test - time_start_test
+
+        return TestResult(
+            sequences=test_sequence_results, metadata=dict(test_time=[test_time])
+        )
 
     def evaluate_stability_of_sequence(
         self,


### PR DESCRIPTION
- stability tests did not run for RnnInit, since the model class was not of type NormalizedHiddenStateInitializerPredictorModel
- add testing time to metadata for stability tests