### PR TITLE
Add bias

### DIFF
--- a/src/deepsysid/models/recurrent.py
+++ b/src/deepsysid/models/recurrent.py
@@ -567,6 +567,7 @@ class ConstrainedRnnConfig(DynamicIdentificationModelConfig):
     epochs_initializer: int
     epochs_predictor: int
     loss: Literal['mse', 'msge']
+    bias: bool
     log_min_max_real_eigenvalues: Optional[bool] = False
 
 
@@ -614,6 +615,7 @@ class ConstrainedRnn(base.NormalizedHiddenStateInitializerPredictorModel):
             nw=self.recurrent_dim,
             gamma=config.gamma,
             beta=config.beta,
+            bias=config.bias,
         ).to(self.device)
 
         self._initializer = rnn.BasicLSTM(
@@ -708,7 +710,10 @@ class ConstrainedRnn(base.NormalizedHiddenStateInitializerPredictorModel):
 
                 # gradient infos
                 grads_norm = [
-                    torch.linalg.norm(p.grad) for p in self._predictor.parameters()
+                    torch.linalg.norm(p.grad)
+                    for p in filter(
+                        lambda p: p.grad is not None, self._predictor.parameters()
+                    )
                 ]
                 max_grad += max(grads_norm)
 

--- a/src/deepsysid/networks/rnn.py
+++ b/src/deepsysid/networks/rnn.py
@@ -215,7 +215,7 @@ class LtiRnn(HiddenStateForwardModule):
 
 class LtiRnnConvConstr(HiddenStateForwardModule):
     def __init__(
-        self, nx: int, nu: int, ny: int, nw: int, gamma: float, beta: float
+        self, nx: int, nu: int, ny: int, nw: int, gamma: float, beta: float, bias: bool
     ) -> None:
         super(LtiRnnConvConstr, self).__init__()
 
@@ -239,6 +239,8 @@ class LtiRnnConvConstr(HiddenStateForwardModule):
         self.C2_tilde = torch.nn.Linear(self.nx, self.nz, bias=False)
         self.D21_tilde = torch.nn.Linear(self.nu, self.nz, bias=False)
         self.lambdas = torch.nn.Parameter(torch.zeros((self.nw, 1)))
+        self.b_z = torch.nn.Parameter(torch.zeros((self.nz)), requires_grad=bias)
+        self.b_y = torch.nn.Parameter(torch.zeros((self.ny)), requires_grad=bias)
 
     def initialize_lmi(self) -> None:
         # storage function
@@ -363,9 +365,9 @@ class LtiRnnConvConstr(HiddenStateForwardModule):
             x = torch.zeros((n_batch, self.nx))
 
         for k in range(n_sample):
-            z = (self.C2_tilde(x) + self.D21_tilde(x_pred[:, k, :])) @ T_inv
+            z = (self.C2_tilde(x) + self.D21_tilde(x_pred[:, k, :]) + self.b_z) @ T_inv
             w = self.nl(z)
-            y[:, k, :] = self.C1(x) + self.D11(x_pred[:, k, :]) + self.D12(w)
+            y[:, k, :] = self.C1(x) + self.D11(x_pred[:, k, :]) + self.D12(w) + self.b_y
             x = (
                 self.A_tilde(x) + self.B1_tilde(x_pred[:, k, :]) + self.B2_tilde(w)
             ) @ Y_inv

--- a/tests/smoke_tests/test_pipeline.py
+++ b/tests/smoke_tests/test_pipeline.py
@@ -121,6 +121,7 @@ def test_constrained_rnn(tmp_path: pathlib.Path) -> None:
         epochs_initializer=2,
         epochs_predictor=2,
         loss='mse',
+        bias=True,
     )
     pipeline.run_pipeline(tmp_path, model_name, model_class, model_config=config)
 
@@ -147,6 +148,7 @@ def test_constrained_rnn_stable(tmp_path: pathlib.Path) -> None:
         batch_size=2,
         epochs_initializer=2,
         epochs_predictor=2,
+        bias=True,
         loss='mse',
     )
     pipeline.run_pipeline(tmp_path, model_name, model_class, model_config=config)


### PR DESCRIPTION
- Theory is easier if the LTI system does not contain bias terms, however, they might improve prediction results
- Bias can be added to constrainedRnn via configuration `bias`